### PR TITLE
[fixes #30961463] fix main core page broken.

### DIFF
--- a/doc/Helper.html
+++ b/doc/Helper.html
@@ -161,7 +161,7 @@
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:23 2012 by 
+  Generated on Sun Jun 10 10:30:32 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims.html
+++ b/doc/Lims.html
@@ -112,7 +112,7 @@
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:21 2012 by 
+  Generated on Sun Jun 10 10:30:30 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core.html
+++ b/doc/Lims/Core.html
@@ -82,7 +82,36 @@
 <h2>Overview</h2><div class="docstring">
   <div class="discussion">
     
-<p>vi: ts=2:sts=2:et:sw=2 spell:spelllang=en</p>
+<p>The Core of the <span class='object_link'><a href="../Lims.html" title="Lims (module)">LIM S</a></span>ystem. Includes the basic classes corresponding
+to the :</p>
+<ol><li>
+<p>domain(s)</p>
+</li><li>
+<p>Persistence Layer</p>
+</li><li>
+<p>Business Logic layer (extension ?)</p>
+</li></ol>
+
+<p>The Core is split in the following submodule/namespace :</p>
+<ol><li>
+<p><span class='object_link'><a href="Core/Laboratory.html" title="Lims::Core::Laboratory (module)">Laboratory</a></span> : Things used/found in the lab. Includes pure laboratory
+(inert things as <span class='object_link'><a href="Core/Laboratory/Plate.html" title="Lims::Core::Laboratory::Plate (class)">plates</a></span>, <span class='object_link'><a href="Core/Laboratory/Tube.html" title="Lims::Core::Laboratory::Tube (class)">tubes</a></span>) and
+chemical one (as <span class='object_link'><a href="Core/Laboratory/Aliquot.html" title="Lims::Core::Laboratory::Aliquot (class)">aliquots</a></span>, <span class='object_link'><a href="Core/Laboratory/Sample.html" title="Lims::Core::Laboratory::Sample (class)">samples</a></span>).</p>
+</li><li>
+<p>LabProcess Related to the work people/robot do in the laboratories.</p>
+</li><li>
+<p><span class='object_link'><a href="Core/Organization.html" title="Lims::Core::Organization (module)">Organization</a></span> Related to users, data release (<span class='object_link'><a href="Core/Organization/Study.html" title="Lims::Core::Organization::Study (class)">studies</a></span>) and ordering (<span class='object_link'><a href="Core/Organization/Order.html" title="Lims::Core::Organization::Order (class)">orders</a></span>) and funding
+(<span class='object_link'><a href="Core/Organization/Project.html" title="Lims::Core::Organization::Project (class)">projects</a></span>) etc.</p>
+</li><li>
+<p><span class='object_link'><a href="Core/Actions.html" title="Lims::Core::Actions (module)">Actions</a></span> High level <span class='object_link'><a href="Core/Actions/Action.html" title="Lims::Core::Actions::Action (module)">actions</a></span> that can be performed on
+things (mostly laboratory).</p>
+</li><li>
+<p><span class='object_link'><a href="Core/Persistence.html" title="Lims::Core::Persistence (module)">Persistence</a></span></p>
+</li></ol>
+
+<p>This partition is more for clarity/documentation purposes and it's not
+meant to be really tight.  However it's more likely than the submodules
+dependency will be a tree than a graph, (but it's not a necessity).</p>
 
 
   </div>
@@ -239,7 +268,7 @@
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:21 2012 by 
+  Generated on Sun Jun 10 10:30:30 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Action.html
+++ b/doc/Lims/Core/Action.html
@@ -89,7 +89,7 @@
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:22 2012 by 
+  Generated on Sun Jun 10 10:30:32 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Actions.html
+++ b/doc/Lims/Core/Actions.html
@@ -224,7 +224,7 @@ probably each correspond to one call in the API.</p>
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:21 2012 by 
+  Generated on Sun Jun 10 10:30:30 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Actions/Action.html
+++ b/doc/Lims/Core/Actions/Action.html
@@ -86,10 +86,10 @@
     
 <p>This mixin add the Action behavior to a class. An action can be called and
 reverted (if possible) within a <span class='object_link'><a href="../Persistence/Session.html" title="Lims::Core::Persistence::Session (class)">session</a></span>. For this,
-the action must implements the Action#_call_in_session and
-revert_in_session. Those methods are private and take a session as a
-parameter. The public equivalent (call/revert) will create a session (using
-the store) and call the corresponding methods.</p>
+the action must implements the _call_in_session and _revert_in_session.
+Those methods are private and take a session as a parameter. The public
+equivalent (call/revert) will create a session (using the store) and call
+the corresponding methods.</p>
 
 
   </div>
@@ -211,7 +211,7 @@ the store) and call the corresponding methods.</p>
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:21 2012 by 
+  Generated on Sun Jun 10 10:30:31 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Actions/Action/AfterEval.html
+++ b/doc/Lims/Core/Actions/Action/AfterEval.html
@@ -460,7 +460,7 @@ _revert_in_session, and shouldn't be overriden.</p>
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:21 2012 by 
+  Generated on Sun Jun 10 10:30:31 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Actions/CreatePlate.html
+++ b/doc/Lims/Core/Actions/CreatePlate.html
@@ -262,7 +262,7 @@
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:23 2012 by 
+  Generated on Sun Jun 10 10:30:32 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Actions/CreateTube.html
+++ b/doc/Lims/Core/Actions/CreateTube.html
@@ -263,7 +263,7 @@
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:23 2012 by 
+  Generated on Sun Jun 10 10:30:32 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Actions/PlateTransfer.html
+++ b/doc/Lims/Core/Actions/PlateTransfer.html
@@ -224,7 +224,7 @@ attributes.</p>
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:23 2012 by 
+  Generated on Sun Jun 10 10:30:33 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Actions/TagWells.html
+++ b/doc/Lims/Core/Actions/TagWells.html
@@ -203,7 +203,7 @@
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:22 2012 by 
+  Generated on Sun Jun 10 10:30:31 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Actions/TransferWellsToTubes.html
+++ b/doc/Lims/Core/Actions/TransferWellsToTubes.html
@@ -297,7 +297,7 @@ attributes.</p>
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:25 2012 by 
+  Generated on Sun Jun 10 10:30:34 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Laboratory.html
+++ b/doc/Lims/Core/Laboratory.html
@@ -116,7 +116,7 @@
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:21 2012 by 
+  Generated on Sun Jun 10 10:30:31 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Laboratory/Aliquot.html
+++ b/doc/Lims/Core/Laboratory/Aliquot.html
@@ -315,7 +315,7 @@ bait library.</p>
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:22 2012 by 
+  Generated on Sun Jun 10 10:30:32 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Laboratory/Container.html
+++ b/doc/Lims/Core/Laboratory/Container.html
@@ -111,7 +111,7 @@ Example, a plate or a tube rack.</p>
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:23 2012 by 
+  Generated on Sun Jun 10 10:30:32 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Laboratory/Container/ClassMethods.html
+++ b/doc/Lims/Core/Laboratory/Container/ClassMethods.html
@@ -184,7 +184,7 @@ over the contained objects.</p>
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:23 2012 by 
+  Generated on Sun Jun 10 10:30:32 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Laboratory/Flowcell.html
+++ b/doc/Lims/Core/Laboratory/Flowcell.html
@@ -253,7 +253,7 @@
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:22 2012 by 
+  Generated on Sun Jun 10 10:30:32 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Laboratory/Flowcell/Lane.html
+++ b/doc/Lims/Core/Laboratory/Flowcell/Lane.html
@@ -195,7 +195,7 @@
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:22 2012 by 
+  Generated on Sun Jun 10 10:30:32 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Laboratory/Labellable.html
+++ b/doc/Lims/Core/Laboratory/Labellable.html
@@ -314,7 +314,7 @@ position is left to pipeline.</p>
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:23 2012 by 
+  Generated on Sun Jun 10 10:30:32 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Laboratory/Oligo.html
+++ b/doc/Lims/Core/Laboratory/Oligo.html
@@ -354,7 +354,7 @@ other samples in the same multiplex.</p>
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:22 2012 by 
+  Generated on Sun Jun 10 10:30:31 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Laboratory/Plate.html
+++ b/doc/Lims/Core/Laboratory/Plate.html
@@ -737,7 +737,7 @@ name</p>
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:22 2012 by 
+  Generated on Sun Jun 10 10:30:31 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Laboratory/Plate/AccessibleViaSuper.html
+++ b/doc/Lims/Core/Laboratory/Plate/AccessibleViaSuper.html
@@ -269,7 +269,7 @@
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:22 2012 by 
+  Generated on Sun Jun 10 10:30:31 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Laboratory/Plate/Well.html
+++ b/doc/Lims/Core/Laboratory/Plate/Well.html
@@ -212,7 +212,7 @@
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:22 2012 by 
+  Generated on Sun Jun 10 10:30:31 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Laboratory/Receptacle.html
+++ b/doc/Lims/Core/Laboratory/Receptacle.html
@@ -286,7 +286,7 @@ bait library.</p>
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:23 2012 by 
+  Generated on Sun Jun 10 10:30:32 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Laboratory/Sample.html
+++ b/doc/Lims/Core/Laboratory/Sample.html
@@ -123,7 +123,7 @@
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:22 2012 by 
+  Generated on Sun Jun 10 10:30:31 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Laboratory/TagGroup.html
+++ b/doc/Lims/Core/Laboratory/TagGroup.html
@@ -250,7 +250,7 @@
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:23 2012 by 
+  Generated on Sun Jun 10 10:30:32 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Laboratory/Tube.html
+++ b/doc/Lims/Core/Laboratory/Tube.html
@@ -140,7 +140,7 @@ something to identifiy it.</p>
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:21 2012 by 
+  Generated on Sun Jun 10 10:30:31 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Organization.html
+++ b/doc/Lims/Core/Organization.html
@@ -115,7 +115,7 @@ funding, ordering etc.</p>
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:21 2012 by 
+  Generated on Sun Jun 10 10:30:31 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Organization/Order.html
+++ b/doc/Lims/Core/Organization/Order.html
@@ -116,7 +116,7 @@ be sequenced in a particular way.</p>
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:22 2012 by 
+  Generated on Sun Jun 10 10:30:31 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Organization/Project.html
+++ b/doc/Lims/Core/Organization/Project.html
@@ -115,7 +115,7 @@
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:23 2012 by 
+  Generated on Sun Jun 10 10:30:32 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Organization/Releasable.html
+++ b/doc/Lims/Core/Organization/Releasable.html
@@ -93,7 +93,7 @@
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:24 2012 by 
+  Generated on Sun Jun 10 10:30:33 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Organization/Study.html
+++ b/doc/Lims/Core/Organization/Study.html
@@ -125,7 +125,7 @@ number. Correspond roughly to a published paper.</p>
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:22 2012 by 
+  Generated on Sun Jun 10 10:30:32 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Organization/User.html
+++ b/doc/Lims/Core/Organization/User.html
@@ -115,7 +115,7 @@
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:22 2012 by 
+  Generated on Sun Jun 10 10:30:31 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Persistence.html
+++ b/doc/Lims/Core/Persistence.html
@@ -518,7 +518,7 @@ Persistence module but which  haven't been subclassed.</p>
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:21 2012 by 
+  Generated on Sun Jun 10 10:30:31 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Persistence/Aliquot.html
+++ b/doc/Lims/Core/Persistence/Aliquot.html
@@ -164,7 +164,7 @@ Sequel::Aliquot) should include the suitable persistor.</p>
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:22 2012 by 
+  Generated on Sun Jun 10 10:30:32 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Persistence/Flowcell.html
+++ b/doc/Lims/Core/Persistence/Flowcell.html
@@ -174,7 +174,7 @@ Sequel::Flowcell) should include the suitable persistor.</p>
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:23 2012 by 
+  Generated on Sun Jun 10 10:30:32 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Persistence/Flowcell/Lane.html
+++ b/doc/Lims/Core/Persistence/Flowcell/Lane.html
@@ -236,7 +236,7 @@ Sequel::Lane) should include the suitable persistor.</p>
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:23 2012 by 
+  Generated on Sun Jun 10 10:30:32 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Persistence/IdentityMap.html
+++ b/doc/Lims/Core/Persistence/IdentityMap.html
@@ -407,7 +407,7 @@ found.</p>
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:24 2012 by 
+  Generated on Sun Jun 10 10:30:33 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Persistence/IdentityMap/DuplicateError.html
+++ b/doc/Lims/Core/Persistence/IdentityMap/DuplicateError.html
@@ -122,7 +122,7 @@
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:24 2012 by 
+  Generated on Sun Jun 10 10:30:33 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Persistence/IdentityMap/DuplicateIdError.html
+++ b/doc/Lims/Core/Persistence/IdentityMap/DuplicateIdError.html
@@ -125,7 +125,7 @@
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:24 2012 by 
+  Generated on Sun Jun 10 10:30:33 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Persistence/IdentityMap/DuplicateObjectError.html
+++ b/doc/Lims/Core/Persistence/IdentityMap/DuplicateObjectError.html
@@ -125,7 +125,7 @@
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:24 2012 by 
+  Generated on Sun Jun 10 10:30:33 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Persistence/IdentityMapClass.html
+++ b/doc/Lims/Core/Persistence/IdentityMapClass.html
@@ -124,7 +124,7 @@
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:23 2012 by 
+  Generated on Sun Jun 10 10:30:32 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Persistence/Logger.html
+++ b/doc/Lims/Core/Persistence/Logger.html
@@ -103,7 +103,7 @@
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:23 2012 by 
+  Generated on Sun Jun 10 10:30:32 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Persistence/Logger/Array.html
+++ b/doc/Lims/Core/Persistence/Logger/Array.html
@@ -116,7 +116,7 @@
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:23 2012 by 
+  Generated on Sun Jun 10 10:30:32 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Persistence/Logger/Persistor.html
+++ b/doc/Lims/Core/Persistence/Logger/Persistor.html
@@ -105,7 +105,7 @@ behavior.</p>
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:25 2012 by 
+  Generated on Sun Jun 10 10:30:34 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Persistence/Logger/Session.html
+++ b/doc/Lims/Core/Persistence/Logger/Session.html
@@ -436,7 +436,7 @@
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:24 2012 by 
+  Generated on Sun Jun 10 10:30:33 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Persistence/Logger/Store.html
+++ b/doc/Lims/Core/Persistence/Logger/Store.html
@@ -450,7 +450,7 @@
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:24 2012 by 
+  Generated on Sun Jun 10 10:30:33 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Persistence/Oligo.html
+++ b/doc/Lims/Core/Persistence/Oligo.html
@@ -156,7 +156,7 @@ Sequel::Plate) should include the suitable persistor.</p>
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:22 2012 by 
+  Generated on Sun Jun 10 10:30:31 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Persistence/Persistor.html
+++ b/doc/Lims/Core/Persistence/Persistor.html
@@ -818,7 +818,7 @@ we don't use the indentity map. Save objects if needed.</p>
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:23 2012 by 
+  Generated on Sun Jun 10 10:30:32 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Persistence/Plate.html
+++ b/doc/Lims/Core/Persistence/Plate.html
@@ -460,7 +460,7 @@ to the session.</p>
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:22 2012 by 
+  Generated on Sun Jun 10 10:30:31 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Persistence/Plate/Well.html
+++ b/doc/Lims/Core/Persistence/Plate/Well.html
@@ -232,7 +232,7 @@ Sequel::Well) should include the suitable persistor.</p>
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:22 2012 by 
+  Generated on Sun Jun 10 10:30:31 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Persistence/Sequel.html
+++ b/doc/Lims/Core/Persistence/Sequel.html
@@ -115,7 +115,7 @@ implements abstract/base classes : <span class='object_link'><a href="Sequel/Sto
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:22 2012 by 
+  Generated on Sun Jun 10 10:30:31 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Persistence/Sequel/Aliquot.html
+++ b/doc/Lims/Core/Persistence/Sequel/Aliquot.html
@@ -372,7 +372,7 @@
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:24 2012 by 
+  Generated on Sun Jun 10 10:30:33 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Persistence/Sequel/Flowcell.html
+++ b/doc/Lims/Core/Persistence/Sequel/Flowcell.html
@@ -643,7 +643,7 @@ added to the session.</p>
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:25 2012 by 
+  Generated on Sun Jun 10 10:30:34 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Persistence/Sequel/Flowcell/Lane.html
+++ b/doc/Lims/Core/Persistence/Sequel/Flowcell/Lane.html
@@ -430,7 +430,7 @@
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:25 2012 by 
+  Generated on Sun Jun 10 10:30:34 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Persistence/Sequel/Persistor.html
+++ b/doc/Lims/Core/Persistence/Sequel/Persistor.html
@@ -365,7 +365,7 @@ behavior.</p>
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:25 2012 by 
+  Generated on Sun Jun 10 10:30:34 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Persistence/Sequel/Plate.html
+++ b/doc/Lims/Core/Persistence/Sequel/Plate.html
@@ -489,7 +489,7 @@ to the session.</p>
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:24 2012 by 
+  Generated on Sun Jun 10 10:30:33 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Persistence/Sequel/Plate/Well.html
+++ b/doc/Lims/Core/Persistence/Sequel/Plate/Well.html
@@ -430,7 +430,7 @@
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:24 2012 by 
+  Generated on Sun Jun 10 10:30:33 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Persistence/Sequel/Session.html
+++ b/doc/Lims/Core/Persistence/Sequel/Session.html
@@ -144,7 +144,7 @@
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:24 2012 by 
+  Generated on Sun Jun 10 10:30:33 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Persistence/Sequel/Store.html
+++ b/doc/Lims/Core/Persistence/Sequel/Store.html
@@ -395,7 +395,7 @@ of the database</p>
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:24 2012 by 
+  Generated on Sun Jun 10 10:30:33 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Persistence/Sequel/TagGroup.html
+++ b/doc/Lims/Core/Persistence/Sequel/TagGroup.html
@@ -309,7 +309,7 @@
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:25 2012 by 
+  Generated on Sun Jun 10 10:30:34 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Persistence/Sequel/TagGroup/Association.html
+++ b/doc/Lims/Core/Persistence/Sequel/TagGroup/Association.html
@@ -364,7 +364,7 @@
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:25 2012 by 
+  Generated on Sun Jun 10 10:30:34 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Persistence/Sequel/Tube.html
+++ b/doc/Lims/Core/Persistence/Sequel/Tube.html
@@ -300,7 +300,7 @@ elements (example aliquots)</p>
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:24 2012 by 
+  Generated on Sun Jun 10 10:30:33 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Persistence/Sequel/Tube/TubeAliquot.html
+++ b/doc/Lims/Core/Persistence/Sequel/Tube/TubeAliquot.html
@@ -335,7 +335,7 @@
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:24 2012 by 
+  Generated on Sun Jun 10 10:30:33 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Persistence/Session.html
+++ b/doc/Lims/Core/Persistence/Session.html
@@ -870,7 +870,7 @@ inside a sess</p>
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:23 2012 by 
+  Generated on Sun Jun 10 10:30:32 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Persistence/Store.html
+++ b/doc/Lims/Core/Persistence/Store.html
@@ -579,7 +579,7 @@ session.</p>
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:22 2012 by 
+  Generated on Sun Jun 10 10:30:31 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Persistence/TagGroup.html
+++ b/doc/Lims/Core/Persistence/TagGroup.html
@@ -462,7 +462,7 @@ to the session.</p>
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:23 2012 by 
+  Generated on Sun Jun 10 10:30:32 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Persistence/TagGroup/Association.html
+++ b/doc/Lims/Core/Persistence/TagGroup/Association.html
@@ -148,7 +148,7 @@ association. It probably correspond to one table on the database.</p>
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:23 2012 by 
+  Generated on Sun Jun 10 10:30:32 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Persistence/Tube.html
+++ b/doc/Lims/Core/Persistence/Tube.html
@@ -460,7 +460,7 @@ to the session.</p>
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:22 2012 by 
+  Generated on Sun Jun 10 10:30:31 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Persistence/Tube/TubeAliquot.html
+++ b/doc/Lims/Core/Persistence/Tube/TubeAliquot.html
@@ -136,7 +136,7 @@
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:22 2012 by 
+  Generated on Sun Jun 10 10:30:31 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Resource.html
+++ b/doc/Lims/Core/Resource.html
@@ -285,7 +285,7 @@ regardless they are the same ruby object or not.</p>
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:21 2012 by 
+  Generated on Sun Jun 10 10:30:30 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Resource/AccessibleViaSuper.html
+++ b/doc/Lims/Core/Resource/AccessibleViaSuper.html
@@ -184,7 +184,7 @@
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:21 2012 by 
+  Generated on Sun Jun 10 10:30:30 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Resource/ClassMethod.html
+++ b/doc/Lims/Core/Resource/ClassMethod.html
@@ -175,7 +175,7 @@
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:21 2012 by 
+  Generated on Sun Jun 10 10:30:30 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Lims/Core/Resource/IsArrayOf.html
+++ b/doc/Lims/Core/Resource/IsArrayOf.html
@@ -539,7 +539,7 @@
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:21 2012 by 
+  Generated on Sun Jun 10 10:30:30 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/Object.html
+++ b/doc/Object.html
@@ -162,7 +162,7 @@
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:21 2012 by 
+  Generated on Sun Jun 10 10:30:30 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/_index.html
+++ b/doc/_index.html
@@ -720,7 +720,7 @@
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:21 2012 by 
+  Generated on Sun Jun 10 10:30:30 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/file.README.html
+++ b/doc/file.README.html
@@ -117,7 +117,7 @@ possible to the use <code>@markup</code> switch.</p>
 </div></div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:21 2012 by 
+  Generated on Sun Jun 10 10:30:30 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/index.html
+++ b/doc/index.html
@@ -117,7 +117,7 @@ possible to the use <code>@markup</code> switch.</p>
 </div></div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:21 2012 by 
+  Generated on Sun Jun 10 10:30:30 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/doc/top-level-namespace.html
+++ b/doc/top-level-namespace.html
@@ -242,7 +242,7 @@
 </div>
     
     <div id="footer">
-  Generated on Sat Jun  9 10:07:25 2012 by 
+  Generated on Sun Jun 10 10:30:34 2012 by 
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.7.5 (ruby-1.9.3).
 </div>

--- a/lib/lims-core/persistence/logger/persistor.rb
+++ b/lib/lims-core/persistence/logger/persistor.rb
@@ -1,5 +1,6 @@
 # vi: ts=2:sts=2:et:sw=2 spell:spelllang=en
 
+
 module Lims::Core
   module Persistence
     module Logger


### PR DESCRIPTION
Add blank lines between modeline and class declaration.
Without that, the modeline is seen as the documentation of the
following object : Lims::Core.
