### PR TITLE
[fixes #40345057] Adding travis build configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+install: bundle install --without debugging pry autotest yard showoff

--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,9 @@ source "http://rubygems.org"
 # Specify your gem's dependencies in lims-core.gemspec
 gemspec
 
-group :development do
+group :debugging do
   gem 'debugger'
   gem 'debugger-completion'
-  gem 'rake'
 end
 
 group :pry do

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,5 @@
 require "bundler/gem_tasks"
+
+require 'rspec/core/rake_task'
+RSpec::Core::RakeTask.new(:spec)
+task :default => :spec

--- a/lims-core.gemspec
+++ b/lims-core.gemspec
@@ -36,4 +36,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('yard', '>= 0.7.0')
   s.add_development_dependency('yard-rspec', '0.1')
   s.add_development_dependency('sqlite3')
+  s.add_development_dependency('rake')
 end


### PR DESCRIPTION
This puts in the necessary changes to get the lims-core project to build using Travis CI.  I've configured the sanger/lims-core project to hook into Travis CI, so this pull request should trigger a build, at least under my github user.
