### PR TITLE
[#42359137] fixed persistence behaviour in case of update

### DIFF
--- a/lib/lims-core/persistence/labellable.rb
+++ b/lib/lims-core/persistence/labellable.rb
@@ -13,6 +13,10 @@ module Lims::Core
         @session.send("Labellable::Label")
       end
 
+      def save(object, *params)
+        save_object(object, {:name => object.name}, *params)
+      end
+
       # Saves all children of a given Labellable
       def save_children(id, labellable)
         labellable.each do |position, label_object|
@@ -29,6 +33,10 @@ module Lims::Core
 
       class Label < Persistor
         Model = Laboratory::Labellable::Label
+
+        def save(object, *params)
+          save_object(object, {:value => object.value}, *params)
+        end
       end
     end
   end

--- a/lib/lims-core/persistence/persistor.rb
+++ b/lib/lims-core/persistence/persistor.rb
@@ -51,6 +51,21 @@ module Lims::Core
           map_id_object(save_new(object, *params) , object)
       end
 
+      # Saves or updates a non-uuidable object
+      # and returns its id or nil if failure
+      # @return [Fixnum, nil]
+      def save_object(object, criteria, *params)
+        return nil if object.nil?
+        id = ids_for(criteria).first
+        id.tap do
+          if id.nil?
+            map_id_object(save_new(object, *params) , object)
+          else
+            update(object, id, *params)
+          end
+        end
+      end
+
       # deletes an object and returns its id or nil if failure
       # @return [Fixnum, nil]
       def delete(object, *params)


### PR DESCRIPTION
If the user loads an existing labellable from the DB and change one or more of its fields and what to persist it back to the DB, then the persistor created a new record in the DB and not updated the existing one.
In this case, instead of the uuid, I use the id to update an object in the DB.
