### PR TITLE
[fixes #44382703] Fix side effect with fraction

### DIFF
--- a/lib/lims-core/actions/transfer_tubes_to_tubes.rb
+++ b/lib/lims-core/actions/transfer_tubes_to_tubes.rb
@@ -40,17 +40,20 @@ module Lims::Core
       def _call_in_session(session)
         sources = []
         targets = []
+        amounts = []
         transfers.each do |transfer|
           fraction = transfer["fraction"]
-          next unless fraction
-          amount = transfer["source"].quantity * fraction
-          transfer["amount"] = amount
+          if fraction
+            amounts << transfer["source"].quantity * fraction
+          else
+            amounts << transfer["amount"]
+          end
         end
 
-        transfers.each do |transfer|
+        transfers.zip(amounts) do |transfer, amount|
           source = transfer["source"]
           target = transfer["target"]
-          target << source.take_amount(transfer["amount"])
+          target << source.take_amount(amount)
 
           unless transfer["aliquot_type"].nil?
             target.each do |aliquot|

--- a/lib/lims-core/version.rb
+++ b/lib/lims-core/version.rb
@@ -1,5 +1,5 @@
 module Lims
   module Core
-    VERSION = "1.2.0.4.0"
+    VERSION = "1.2.0.4.1"
   end
 end


### PR DESCRIPTION
When we convert the fraction to amount, we added 
a new element to the transfer hash. It was an 
unwanted side effect. I refactored a code to use 
a separate array for the amounts.
