### PR TITLE
[fixes #45076439] Fix response JSON of transfer actions

### DIFF
--- a/lib/lims-core/actions/plate_transfer.rb
+++ b/lib/lims-core/actions/plate_transfer.rb
@@ -26,7 +26,7 @@ module Lims::Core
       def _call_in_session(session)
         transfers = _transfers
         transfer_hash = _transfer(transfers, _amounts(transfers), session)
-        transfer_hash[:targets]
+        transfer_hash[:targets].first
       end
 
     end

--- a/lib/lims-core/actions/transfer_action.rb
+++ b/lib/lims-core/actions/transfer_action.rb
@@ -67,8 +67,8 @@ module Lims::Core
                 end
               end
 
-              sources << _source
-              targets << _target
+              sources << source
+              targets << target
 
             end
 

--- a/lib/lims-core/version.rb
+++ b/lib/lims-core/version.rb
@@ -10,6 +10,7 @@ module Lims
     --llh1
     --ke4
   x
+    x
     --mb14
     x
 


### PR DESCRIPTION
We should add the whole object to the response JSON 
and not just a wells/windows in case of plate/gel.
