### PR TITLE
[fixes #45136133] Added multiply tube rack move action

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lims-core (1.3.0.1.2)
+    lims-core (1.3.0.2.0)
       active_support
       aequitas
       bunny (= 0.9.0.pre4)

--- a/lib/lims-core/actions/tube_rack_move.rb
+++ b/lib/lims-core/actions/tube_rack_move.rb
@@ -4,29 +4,43 @@ require 'lims/core/laboratory/tube_rack'
 
 module Lims::Core
   module Actions
-    # This action moves physically tubes from a source rack
-    # to a target rack according to a transfer map.
+    # This {Action} moves physically tubes from source racks
+    # to target racks.
+    # It takes an array, which contains the elements of the movement.
+    # An element has a source, source_location, target and target_location.
+    # Source and targets are tube racks.
+    # The source/target_location is the tube location (like "A1") from
+    # move the tube and to move the tube.
     class TubeRackMove
       include Action
 
-      attribute :source, Laboratory::TubeRack, :required => true, :writer => :private
-      attribute :target, Laboratory::TubeRack, :required => true, :writer => :private
-      attribute :move_map, Hash, :required => true, :writer => :private
+      attribute :moves, Array, :required => true, :writer => :private
 
-      # Move tubes from a source tube rack to a target
-      # tube rack. If a tube is already present in the
+      # Move tubes from source tube racks to target
+      # tube racks. If a tube is already present in the
       # target location, a RackPositionNotEmpty exception
       # is raised in the Laboratory::TubeRack class.
-      # The tube is removed from the source tube rack.
+      # The tube is removed from the source tube rack 
+      # after moving to its target location.
       def _call_in_session(session)
-        move_map.each do |from, to|
+        targets = []
+        moves.each do |move|
+          source = move["source"]
+          from = move["source_location"]
+          target = move["target"]
+          to = move["target_location"]
+
           unless source[from].nil?
             target[to] = source[from]
             source[from] = nil
           end
+
+          targets << target
         end
-        target
+
+        targets
       end
+
     end
   end
 end

--- a/lib/lims-core/version.rb
+++ b/lib/lims-core/version.rb
@@ -9,15 +9,14 @@ module Lims
     MINOR_DEV = %{
     --llh1
     --ke4
-  x
     --mb14
-    x
 
   }
     MAJOR_DEV = %{
     --llh1
     --ke4
-  x
+    x
+    x
     --mb14
 
 }

--- a/spec/actions/tube_rack_move_spec.rb
+++ b/spec/actions/tube_rack_move_spec.rb
@@ -7,22 +7,18 @@ require 'laboratory/tube_rack_shared'
 require 'lims/core/actions/tube_rack_move'
 require 'lims/core/persistence/sequel/store'
 
-
 module Lims::Core
   module Actions
     describe TubeRackMove do
       context "with a sequel store" do
         include_context "for application", "test tube rack move"
-        include_context "prepare tables"
+        include_context "sequel store"
         include_context "tube_rack factory"
 
         let(:number_of_rows) { 8 }
         let(:number_of_columns) { 12 }
-        let(:db) { ::Sequel.sqlite('') }
-        let(:store) { Persistence::Sequel::Store.new(db) }
-        before(:each) { prepare_table(db) }
 
-        let(:source_id) {
+        let(:source1_id) {
           store.with_session do |session|
             rack = new_tube_rack_with_samples(1)
             session << rack
@@ -30,9 +26,25 @@ module Lims::Core
           end.call
         }
 
-        let(:target_id) {
+        let(:source2_id) {
           store.with_session do |session|
-            rack = target_tube_rack 
+            rack = new_tube_rack_with_samples(1)
+            session << rack
+            lambda { session.tube_rack.id_for(rack) }
+          end.call
+        }
+
+        let(:target1_id) {
+          store.with_session do |session|
+            rack = target_tube_rack1
+            session << rack
+            lambda { session.tube_rack.id_for(rack) }
+          end.call
+        }
+
+        let(:target2_id) {
+          store.with_session do |session|
+            rack = target_tube_rack2
             session << rack
             lambda { session.tube_rack.id_for(rack) }
           end.call
@@ -47,13 +59,16 @@ module Lims::Core
 
         # Tube already present in target tube rack
         context "invalid transfer" do
-          let(:target_tube_rack) { new_tube_rack_with_samples(1) }
+          let(:target_tube_rack1) { new_tube_rack_with_samples(1) }
 
           subject do
-            described_class.new(:store => store, :user => user, :application => application) do |a,s|
-              a.source = s.tube_rack[source_id]
-              a.target = s.tube_rack[target_id]
-              a.move_map = {:A4 => :E9}
+            described_class.new(:store => store, :user => user, :application => application) do |action, session|
+              action.moves = [
+                {"source" => session.tube_rack[source1_id],
+                 "source_location" => "A4",
+                 "target" => session.tube_rack[target1_id],
+                 "target_location" => "E9" }
+              ]
             end
           end
 
@@ -63,23 +78,49 @@ module Lims::Core
         end
 
         context "valid transfer" do
-          let(:target_tube_rack) { new_empty_tube_rack }
+          let(:target_tube_rack1) { new_empty_tube_rack }
+          let(:target_tube_rack2) { new_empty_tube_rack }
           before(:each) { subject.call }
           subject do
-            described_class.new(:store => store, :user => user, :application => application) do |a,s|
-              a.source = s.tube_rack[source_id]
-              a.target = s.tube_rack[target_id]
-              a.move_map = {:A4 => :E10}
+            described_class.new(:store => store, :user => user, :application => application) do |action,session|
+              source_tube_rack1, source_tube_rack2 = [source1_id, source2_id].map { |uuid| session.tube_rack[uuid] }
+              action.moves = [
+                {"source" => source_tube_rack1,
+                 "source_location" => "A1",
+                 "target" => target_tube_rack1,
+                 "target_location" => "B9" },
+                {"source" => source_tube_rack1,
+                 "source_location" => "B2",
+                 "target" => target_tube_rack2,
+                 "target_location" => "F3" },
+                {"source" => source_tube_rack2,
+                 "source_location" => "C5",
+                 "target" => target_tube_rack1,
+                 "target_location" => "D4" },
+                {"source" => source_tube_rack2,
+                 "source_location" => "E8",
+                 "target" => target_tube_rack2,
+                 "target_location" => "A9" }
+              ]
             end
           end
 
           it "saves the transfered rack" do
             store.with_session do |session|
-              source = session.tube_rack[source_id]
-              target = session.tube_rack[target_id]
-              source[:A4].should be_nil
-              target[:E10].should_not be_nil
-              target[:E10].should be_a(Lims::Core::Laboratory::Tube)
+              source_tube_rack1, source_tube_rack2 = [source1_id, source2_id].map { |uuid| session.tube_rack[uuid] }
+              source_tube_rack1[:A1].should be_nil
+              source_tube_rack1[:B2].should be_nil
+              source_tube_rack2[:C5].should be_nil
+              source_tube_rack2[:E8].should be_nil
+
+              target_tube_rack1[:B9].should_not be_nil
+              target_tube_rack1[:B9].should be_a(Lims::Core::Laboratory::Tube)
+              target_tube_rack1[:D4].should_not be_nil
+              target_tube_rack1[:D4].should be_a(Lims::Core::Laboratory::Tube)
+              target_tube_rack2[:F3].should_not be_nil
+              target_tube_rack2[:F3].should be_a(Lims::Core::Laboratory::Tube)
+              target_tube_rack2[:A9].should_not be_nil
+              target_tube_rack2[:A9].should be_a(Lims::Core::Laboratory::Tube)
             end
           end
         end


### PR DESCRIPTION
Refactored the tube rack move action to use
multiply source and target laboratory asset.
