### PR TITLE
[fix #48240295] set heartbeat option on RabbitMQ

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lims-core (1.5.0)
+    lims-core (1.5.2)
       active_support
       aequitas
       bunny (= 0.9.0.pre4)
@@ -19,7 +19,7 @@ GEM
       activesupport (= 3.0.0)
     activesupport (3.0.0)
     aequitas (0.0.2)
-    amq-protocol (1.2.0)
+    amq-protocol (1.3.0)
     autotest (4.4.6)
       ZenTest (>= 4.4.1)
     autotest-fsevent (0.2.8)
@@ -87,7 +87,7 @@ GEM
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.8.0)
     ruby-graphviz (1.0.8)
-    sequel (3.45.0)
+    sequel (3.46.0)
     showoff (0.7.0)
       bluecloth
       gli (>= 1.3.2)
@@ -101,7 +101,7 @@ GEM
       tilt (~> 1.3, >= 1.3.3)
     slop (3.3.2)
     sqlite3 (1.3.6)
-    state_machine (1.1.2)
+    state_machine (1.2.0)
     sys-uname (0.9.0)
       ffi (>= 1.0.0)
     systemu (2.5.2)

--- a/lib/lims-core/persistence/message_bus.rb
+++ b/lib/lims-core/persistence/message_bus.rb
@@ -15,6 +15,7 @@ module Lims
         attribute :exchange_name, String, :required => true, :writer => :private
         attribute :durable, Boolean, :required => true, :writer => :private
         attribute :prefetch_number, Integer, :required => true, :writer => :private
+        attribute :heart_beat, Integer, :required => true, :writer => :private
 
         # Exception ConnectionError raised after a failed connection
         # to RabbitMQ server.
@@ -29,6 +30,7 @@ module Lims
         # are passed as parameters.
         # @param [Hash] settings
         def initialize(settings = {})
+          @heart_beat = settings["heart_beat"]
           @connection_uri = settings["url"]
           @exchange_name = settings["exchange_name"]
           @durable = settings["durable"]
@@ -49,7 +51,7 @@ module Lims
         def connect
           begin
             if valid?
-              @connection = Bunny.new(connection_uri)
+              @connection = Bunny.new(connection_uri, :heartbeat => heart_beat)
               @connection.start
               @channel = @connection.create_channel
               set_prefetch_number(prefetch_number)

--- a/lib/lims-core/version.rb
+++ b/lib/lims-core/version.rb
@@ -1,5 +1,5 @@
 module Lims
   module Core
-    VERSION = "1.5.0"
+    VERSION = "1.5.2"
   end
 end

--- a/spec/persistence/message_bus_spec.rb
+++ b/spec/persistence/message_bus_spec.rb
@@ -8,7 +8,8 @@ module Lims::Core
         let(:exchange_name) { "exchange_name" }
         let(:durable) { true }
         let(:prefetch_number) { 30 }
-        let(:bus_settings) { {"url" => url, "exchange_name" => exchange_name, "durable" => durable, "prefetch_number" => prefetch_number} }
+        let(:heart_beat) { 0 }
+        let(:bus_settings) { {"url" => url, "exchange_name" => exchange_name, "durable" => durable, "prefetch_number" => prefetch_number, "heart_beat" => heart_beat} }
 
         it "requires a RabbitMQ host" do
           described_class.new(bus_settings - ["url"]).valid?.should == false
@@ -24,6 +25,10 @@ module Lims::Core
 
         it "requires a prefetch number" do
           described_class.new(bus_settings - ["prefetch_number"]).valid?.should == false
+        end
+
+        it "requires a heart_beat value" do
+          described_class.new(bus_settings - ["heart_beat"]).valid?.should == false
         end
 
         it "requires correct settings" do


### PR DESCRIPTION
We have to set the heartbeat option to the same value on server and client, too.
We have to configure the heartbeat setting in lims-api project in the amqp.yml configuration file under config folder. 
We also have to configure the server to the same value as in the client's configuration value.
