### PR TITLE
set rabbitmq's heartbeat to 0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 PATH
   remote: .
   specs:
-    lims-core (1.5.0.1.3)
+    lims-core (1.5.0.1.4)
       active_support
       aequitas
-      bunny (~> 0.8.0)
+      bunny (= 0.9.0.pre4)
       facets (= 2.9.3)
       sequel
       state_machine
@@ -19,6 +19,7 @@ GEM
       activesupport (= 3.0.0)
     activesupport (3.0.0)
     aequitas (0.0.2)
+    amq-protocol (1.2.0)
     autotest (4.4.6)
       ZenTest (>= 4.4.1)
     autotest-fsevent (0.2.8)
@@ -27,7 +28,8 @@ GEM
     blankslate (2.1.2.4)
     bluecloth (2.2.0)
     bond (0.4.3)
-    bunny (0.8.0)
+    bunny (0.9.0.pre4)
+      amq-protocol (>= 1.0.1)
     coderay (1.0.9)
     columnize (0.3.6)
     debugger (1.5.0)

--- a/lib/lims-core/persistence/message_bus.rb
+++ b/lib/lims-core/persistence/message_bus.rb
@@ -1,5 +1,4 @@
 require 'bunny'
-require 'bunny/exchange'
 require 'common'
 
 module Lims
@@ -16,6 +15,7 @@ module Lims
         attribute :exchange_name, String, :required => true, :writer => :private
         attribute :durable, Boolean, :required => true, :writer => :private
         attribute :prefetch_number, Integer, :required => true, :writer => :private
+        attribute :heart_beat, Integer, :required => true, :writer => :private
 
         # Exception ConnectionError raised after a failed connection
         # to RabbitMQ server.
@@ -30,6 +30,7 @@ module Lims
         # are passed as parameters.
         # @param [Hash] settings
         def initialize(settings = {})
+          @heart_beat = settings["heart_beat"]
           @connection_uri = settings["url"]
           @exchange_name = settings["exchange_name"]
           @durable = settings["durable"]
@@ -50,14 +51,15 @@ module Lims
         def connect
           begin
             if valid?
-              @connection = Bunny.new(connection_uri)
+              @connection = Bunny.new(connection_uri, :heartbeat => heart_beat)
               @connection.start
+              @channel = @connection.create_channel
               set_prefetch_number(prefetch_number)
               set_exchange(exchange_name, :durable => durable)
             else
               raise InvalidSettingsError, "settings are invalid"
             end
-          rescue Bunny::ConnectionError => e
+          rescue Bunny::TCPConnectionFailed, Bunny::PossibleAuthenticationFailureError => e
             connection_failure_handler.call
           end
         end  
@@ -74,14 +76,14 @@ module Lims
         # @param [String] name
         # @param [Hash] exchange options
         def set_exchange(exchange_name, options = {})
-          @exchange = @connection.exchange(exchange_name, options)
+          @exchange = @channel.topic(exchange_name, options)
         end
         private :set_exchange
 
         # Specifies the number of messages to prefetch.
         # @param [int] number of messages to prefetch
         def set_prefetch_number(number)
-          @connection.qos(:prefetch_count => number)
+          @channel.prefetch(number)
         end
         private :set_prefetch_number
 

--- a/lib/lims-core/version.rb
+++ b/lib/lims-core/version.rb
@@ -11,6 +11,7 @@ module Lims
     x
     --ke4
     x
+    x
     --mb14
     x
 

--- a/lims-core.gemspec
+++ b/lims-core.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency('active_support')
   s.add_dependency('uuid')
   s.add_dependency('state_machine')
-  s.add_dependency('bunny', '~>0.8.0')
+  s.add_dependency('bunny', '0.9.0.pre4')
 
 
   #development

--- a/spec/persistence/message_bus_spec.rb
+++ b/spec/persistence/message_bus_spec.rb
@@ -8,7 +8,8 @@ module Lims::Core
         let(:exchange_name) { "exchange_name" }
         let(:durable) { true }
         let(:prefetch_number) { 30 }
-        let(:bus_settings) { {"url" => url, "exchange_name" => exchange_name, "durable" => durable, "prefetch_number" => prefetch_number} }
+        let(:heart_beat) { 0 }
+        let(:bus_settings) { {"url" => url, "exchange_name" => exchange_name, "durable" => durable, "prefetch_number" => prefetch_number, "heart_beat" => heart_beat } }
 
         it "requires a RabbitMQ host" do
           described_class.new(bus_settings - ["url"]).valid?.should == false
@@ -24,6 +25,10 @@ module Lims::Core
 
         it "requires a prefetch number" do
           described_class.new(bus_settings - ["prefetch_number"]).valid?.should == false
+        end
+
+        it "requires a heart_beat value" do
+          described_class.new(bus_settings - ["heart_beat"]).valid?.should == false
         end
 
         it "requires correct settings" do


### PR DESCRIPTION
Specs passed.
Using the 0.9.0.pre4 version of bunny.
The heart_beat setting in RabbitMQ's config file 
should set to 0, too.
