### PR TITLE
49131067 upgrade bunny gem to 0 9 0 pre10 version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 PATH
   remote: .
   specs:
-    lims-core (1.5.0.2.1)
+    lims-core (1.5.0.3.0)
       active_support
       aequitas
-      bunny (= 0.9.0.pre4)
+      bunny (= 0.9.0.pre10)
       facets (= 2.9.3)
       sequel
       state_machine
@@ -19,7 +19,7 @@ GEM
       activesupport (= 3.0.0)
     activesupport (3.0.0)
     aequitas (0.0.2)
-    amq-protocol (1.3.0)
+    amq-protocol (1.4.0)
     autotest (4.4.6)
       ZenTest (>= 4.4.1)
     autotest-fsevent (0.2.8)
@@ -28,8 +28,8 @@ GEM
     blankslate (2.1.2.4)
     bluecloth (2.2.0)
     bond (0.4.3)
-    bunny (0.9.0.pre4)
-      amq-protocol (>= 1.0.1)
+    bunny (0.9.0.pre10)
+      amq-protocol (>= 1.4.0)
     coderay (1.0.9)
     columnize (0.3.6)
     debugger (1.5.0)
@@ -98,7 +98,7 @@ GEM
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.8.0)
     ruby-graphviz (1.0.9)
-    sequel (3.46.0)
+    sequel (3.47.0)
     showoff (0.7.0)
       bluecloth
       gli (>= 1.3.2)

--- a/lib/lims-core/persistence/message_bus.rb
+++ b/lib/lims-core/persistence/message_bus.rb
@@ -51,7 +51,8 @@ module Lims
         def connect
           begin
             if valid?
-              @connection = Bunny.new(connection_uri, :heartbeat => heart_beat)
+              opts = @heart_beat ? { :heartbeat => heart_beat } : {}
+              @connection = Bunny.new(connection_uri, opts)
               @connection.start
               @channel = @connection.create_channel
               set_prefetch_number(prefetch_number)

--- a/lib/lims-core/persistence/message_bus.rb
+++ b/lib/lims-core/persistence/message_bus.rb
@@ -51,8 +51,8 @@ module Lims
         def connect
           begin
             if valid?
-              opts = @heart_beat ? { :heartbeat => heart_beat } : {}
-              @connection = Bunny.new(connection_uri, opts)
+              options = @heart_beat ? { :heartbeat => heart_beat } : {}
+              @connection = Bunny.new(connection_uri, options)
               @connection.start
               @channel = @connection.create_channel
               set_prefetch_number(prefetch_number)

--- a/lib/lims-core/version.rb
+++ b/lib/lims-core/version.rb
@@ -9,13 +9,13 @@ module Lims
     MINOR_DEV = %{
     --llh1
     --ke4
-    x
     --mb14
     }
 
     MAJOR_DEV = %{
     --llh1
     --ke4
+    x
     x
     --mb14
     x

--- a/lims-core.gemspec
+++ b/lims-core.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency('active_support')
   s.add_dependency('uuid')
   s.add_dependency('state_machine')
-  s.add_dependency('bunny', '0.9.0.pre4')
+  s.add_dependency('bunny', '0.9.0.pre10')
 
 
   #development


### PR DESCRIPTION
This bunny version introduces:
- More Reliable Heartbeat Sender
- Network Recovery After Delay
- Default Heartbeat Value Is Now Server-Defined
- Concurrency Improvements On JRuby
- Explicitly Closed Sockets
- Bunny::Exception Now Extends StandardError

http://blog.rubyrabbitmq.info/blog/2013/04/22/bunny-0-dot-9-0-dot-pre9-is-released/
http://blog.rubyrabbitmq.info/blog/2013/05/02/bunny-0-dot-9-0-dot-pre10-is-released/
