### PR TITLE
[fix #49907935] comparison filter should join to other filters

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lims-core (2.0.0.3.1)
+    lims-core (2.0.0.3.2)
       active_support
       aequitas
       bunny (= 0.9.0.pre10)

--- a/lib/lims-core/persistence/search/create_search.rb
+++ b/lib/lims-core/persistence/search/create_search.rb
@@ -18,8 +18,10 @@ module Lims::Core
         def _call_in_session(session)
           # Use the appropriate filter if needed.
           filter = nil
-          if criteria.size == 1 
-            criteria.keys.first.andtap do |model|
+          keys = criteria.keys
+          keys.delete("comparison") if criteria.keys.size > 1
+          if keys.size == 1
+            keys.first.andtap do |model|
               filter_class_name = "#{model.capitalize}Filter"
               if Persistence::const_defined? filter_class_name
                 filter = Persistence::const_get(filter_class_name).new(:criteria => criteria)

--- a/lib/lims-core/version.rb
+++ b/lib/lims-core/version.rb
@@ -10,6 +10,7 @@ module Lims
     --llh1
     --ke4
     x
+    x
     --mb14
     }
 


### PR DESCRIPTION
This piece of code has not been merged to version-2 branch.
Without it the comparison filter can not be join to other filters.

Specs are passing.
