### PR TITLE
Use time_format option when using Oj

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lims-core (3.1.0.0.0)
+    lims-core (3.1.0.0.1)
       active_support
       aequitas
       bunny (= 0.9.0.pre10)

--- a/lib/lims-core/helpers.rb
+++ b/lib/lims-core/helpers.rb
@@ -21,7 +21,7 @@ module Lims::Core
     elsif gem_available?('oj')
       require 'oj'
       def self.to_json(object)
-        Oj.dump(object, :mode => :compat)
+        Oj.dump(object, :mode => :compat, :time_format => :ruby)
       end
 
       def self.load_json(json)

--- a/lib/lims-core/version.rb
+++ b/lib/lims-core/version.rb
@@ -8,6 +8,7 @@ module Lims
     #
     MINOR_DEV = %{
     --llh1
+    x
     --ke4
     --mb14
     }


### PR DESCRIPTION
Example of the bug with Oj and a DateTime object:

1.9.3p392 :002 > h = {:a => {:b => {:date => Time.now.utc}}}
 => {:a=>{:b=>{:date=>2013-10-22 15:38:46 UTC}}}
1.9.3p392 :014 >   Oj.dump h, :mode => :compat
 => "{\"a\":{\"b\":{\"date\":1382456326.732787000}}}"     << NOT EXPECTED
1.9.3p392 :015 > Oj.dump h, :mode => :compat, :time_format => :ruby
 => "{\"a\":{\"b\":{\"date\":\"2013-10-22 15:38:46 UTC\"}}}"
