### PR TITLE
[#64570338] Fix session id bug.

### DIFF
--- a/lib/lims-core/persistence/session.rb
+++ b/lib/lims-core/persistence/session.rb
@@ -215,13 +215,21 @@ module Lims::Core
       private
       # save all objects which needs to be
       def save_all()
-        @store.transaction do
+        transaction do
           @save_in_progress = true # allows saving
           @object_states.reset_status
           @object_states.save
           end
         @save_in_progress = false
       end
+
+      # Execute the provided block within a transaction
+      # Here to be overriden if needed
+      def transaction
+        @store.transaction do
+         yield
+       end
+     end
 
       # Create a new persistor sharing the same internal parameters
       # but with the "context" (datasest) of the new one.


### PR DESCRIPTION
Session id bug seems to appear in a multithreading environment when
another thread reuse an open connection and reset the current_session_id
useb by a previous thread.

This commit fix the bug by setting again the current_session_id at the
beginning of a transaction. Hopefully, a SQL connection shouldn't be
reused by Sequel in the middle of a transaction.
